### PR TITLE
Feat (cicd): Further streamline ci-cd workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -87,16 +87,26 @@ jobs:
           enforce_admins: false
     
     # Step 7. Bump version and tagging
-    - name: Bump version and tagging and publish
+    #- name: Bump version and tagging and publish
+    #  run: |
+    #    git config --local user.email "action@github.com"
+    #    git config --local user.name "GitHub Action"
+    #    git pull origin main
+    #    poetry run semantic-release version
+    #    poetry version
+    #    git commit --amend -m "[skip actions] Bump new version"
+    #    git push --tag
+
+    # Step 7. Use PSR to make release
+    - name: Python Semantic Release
+      env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git pull origin main
-        poetry run semantic-release version
-        poetry version
-        git commit --amend -m "[skip actions] Bump new version"
-        git push --tag
-        
+          pip install python-semantic-release
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          semantic-release publish  
+
     - name: Push package version changes
       uses: ad-m/github-push-action@master
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 <!--next-version-placeholder-->
-## v1.1.0 (01/24/2022)
+## v1.0.15 (01/28/2022)
 
-- CI/CD compatible package
+- Deployed all necessary code
+- Include examples in README
 
 ## v0.1.0 (01/11/2022)
 


### PR DESCRIPTION
This change reverts `semantic-release version` back to `semantic-release publish`. The main reason is to check if CHANGELOG can be updated automatically based on the commits. The drawback is that it introduces one additional workflow after each merge.