### PR TITLE
docs: update readme with correct logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!--next-version-placeholder-->
 
 ## v1.0.19 (2022-01-30)
-
+- Experiment on breaking changes
 
 ## v1.0.18 (2022-01-29)
 - Last minor version before major release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v1.0.19 (2022-01-30)
 - Experiment on breaking changes
+- Make sure the CI-CD workflow works
 
 ## v1.0.18 (2022-01-29)
 - Last minor version before major release

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# covizpy <img src='img/logo.png' align="right" height="139" />
+# covizpy <img src='https://raw.githubusercontent.com/UBC-MDS/covizpy/main/img/logo.png' align="right" height="139" />
 
 [![codecov](https://codecov.io/gh/ubc-mds/covizpy/branch/main/graph/badge.svg?token=bCRbU4Axjx)](https://codecov.io/gh/ubc-mds/covizpy)
 [![ci-cd](https://github.com/UBC-MDS/covizpy/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/UBC-MDS/covizpy/actions/workflows/ci-cd.yml)


### PR DESCRIPTION
This updates the readme file.

BREAKING CHANGE: try to bump the version by updating the logo.